### PR TITLE
Fix MATE desktop screensaver dbus exceptions

### DIFF
--- a/gnomecast.py
+++ b/gnomecast.py
@@ -161,6 +161,17 @@ class Transcoder(object):
     if self.trans_fn and os.path.isfile(self.trans_fn):
       os.remove(self.trans_fn)
 
+def find_screensaver_dbus_iface(bus):
+  """ Searches the DBus names for Screensaver and returns correct Interface"""
+  for path, name in [('org.freedesktop.ScreenSaver', '/ScreenSaver'),
+                     ('org.mate.ScreenSaver', '/ScreenSaver')]:
+    try:
+      saver = bus.get_object(path, name)
+      return dbus.Interface(saver, dbus_interface=path)
+    except dbus.exceptions.DBusException:
+      # wrong path, try next one
+      continue
+    # The exception bubbles up if no alternative found
 
 class Gnomecast(object):
 
@@ -182,8 +193,7 @@ class Gnomecast(object):
     self.seeking = False
     self.last_known_volume_level = None
     bus = dbus.SessionBus()
-    saver = bus.get_object('org.freedesktop.ScreenSaver', '/ScreenSaver')
-    self.saver_interface = dbus.Interface(saver, dbus_interface='org.freedesktop.ScreenSaver')
+    self.saver_interface = find_screensaver_dbus_iface(bus)
     self.inhibit_screensaver_cookie = None
 
   def run(self):

--- a/gnomecast.py
+++ b/gnomecast.py
@@ -171,7 +171,7 @@ def find_screensaver_dbus_iface(bus):
     except dbus.exceptions.DBusException:
       # wrong path, try next one
       continue
-    # The exception bubbles up if no alternative found
+    return None  # None if no alternative found
 
 class Gnomecast(object):
 
@@ -194,7 +194,7 @@ class Gnomecast(object):
     self.last_known_volume_level = None
     bus = dbus.SessionBus()
     self.saver_interface = find_screensaver_dbus_iface(bus)
-    self.inhibit_screensaver_cookie = None
+    self.inhibit_screensaver_cookie = None if self.saver_interface else True
 
   def run(self):
     self.build_gui()


### PR DESCRIPTION
Fixes #36.

I did this fix to scratch my personal itch of MATE desktop.

I'll freely admit the new function is not ideal, and the silent setting of the cookie is sneaky and too smart for its own good by abusing the fact that an `if` check in Python checks for non-nullity/boolean value.

I hope this 5-minute fix can be useful to someone else than me.
Any change required for a prettier merge, I'd be glad to do.
