### PR TITLE
Video thumbnail is now a fixed height, not width.

### DIFF
--- a/gnomecast.py
+++ b/gnomecast.py
@@ -749,7 +749,7 @@ class Gnomecast(object):
     else:
       thumbnail_fn = tempfile.mkstemp(suffix='.jpg', prefix='gnomecast_thumbnail_')[1]
       os.remove(thumbnail_fn)
-      cmd = ['ffmpeg', '-y', '-i', self.fn, '-f', 'mjpeg', '-vframes', '1', '-ss', '27', '-vf', 'scale=600:-1', thumbnail_fn]
+      cmd = ['ffmpeg', '-y', '-i', self.fn, '-f', 'mjpeg', '-vframes', '1', '-ss', '27', '-vf', 'scale=-1:250', thumbnail_fn]
     self.ffmpeg_desc = output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     for line in output.decode().split('\n'):
       line = line.strip()

--- a/gnomecast.py
+++ b/gnomecast.py
@@ -749,7 +749,7 @@ class Gnomecast(object):
     else:
       thumbnail_fn = tempfile.mkstemp(suffix='.jpg', prefix='gnomecast_thumbnail_')[1]
       os.remove(thumbnail_fn)
-      cmd = ['ffmpeg', '-y', '-i', self.fn, '-f', 'mjpeg', '-vframes', '1', '-ss', '27', '-vf', 'scale=-1:250', thumbnail_fn]
+      cmd = ['ffmpeg', '-y', '-i', self.fn, '-f', 'mjpeg', '-vframes', '1', '-ss', '5', '-vf', 'scale=-1:250', thumbnail_fn]
     self.ffmpeg_desc = output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     for line in output.decode().split('\n'):
       line = line.strip()


### PR DESCRIPTION
I noticed that when opening some videos the thumbnail created makes the window too big to display fully on-screen, in my case this meant I couldn't then click on play to 'cast the video. Having looked at the command-line passed to ffmpeg I realised that you were creating a thumbnail of a fixed width, with an auto-sized height, I've just swapped the command-line arguments so that the thumbnail is a fixed height with an auto-sized width.

The current fixed height value works for me, obviously you can tweak it further to suit.

Also now changed the seek position for the thumbnail, since some of videos that I want to 'cast weren't the defined 27 seconds long.