### PR TITLE
Installation fails in clean environment - switch to hardcoded version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def long_description():
 
 setup(
   name='gnomecast',
-  version=__import__('gnomecast').__version__,
+  version='1.4.1',
   description='A native Linux GUI for Chromecasting local files.',
   long_description=long_description(),
   author='Derek Anderson',


### PR DESCRIPTION
# Steps to reproduce
* Create a new venv
* `pip install gnomecast`
* fails complaining about `pychromecast` not being found

# Problem
`setup.py` is importing `gnomecast.py` to find a version number, `gnomecast.py` is in tern importing dependencies that `setup.py` has not installed yet...

This PR just swaps the import for a hardcoded version, mainly because it is simple.

A more complete fix might involve creating a `gnomecast` top level module to hold the python code, with the version defined in `__init__.py` which in turn is then imported from `setup.py` and anywhere else the version is needed. That is a pretty common pattern, you can see it in use in [wagtail](https://github.com/wagtail/wagtail) for example.