### PR TITLE
Add missing dependency to setup.py, document installation instructions for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ What's New
 
 Install
 -------
+
 Please run:
 
 ```
@@ -29,6 +30,27 @@ $ pip3 install gnomecast
 ```
 
 If installing in a `mkvirtualenv` built virtual environment, make sure you include the `--system-site-packages` parameter to get the GTK bindings.
+
+Fedora
+~~~~~~
+
+1. Install OS level dependencies
+
+```bash
+sudo dnf install ffmpeg cairo-gobject-devel gobject-introspection-devel dbus-devel cairo-devel
+```
+
+2. Install Python dependencies
+
+```bash
+pip install pygobject dbus-python
+```
+
+3. Install the application itself
+
+```bash
+pip install gnomecast
+```
 
 Run
 ---

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ sudo dnf install ffmpeg cairo-gobject-devel gobject-introspection-devel dbus-dev
 
 2. Install Python dependencies
 
+NOTE: ``dbus-python`` is an optional dependency.
+
 ```bash
 pip install pygobject dbus-python
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ If installing in a `mkvirtualenv` built virtual environment, make sure you inclu
 Fedora
 ~~~~~~
 
+This section describes how to install this application on Fedora inside a virtual environment
+without relying on ``python3-gobject`` system level package and ``--system-site-packages``
+virtualenv flag.
+
 1. Install OS level dependencies
 
 ```bash
@@ -45,13 +49,13 @@ sudo dnf install ffmpeg cairo-gobject-devel gobject-introspection-devel dbus-dev
 NOTE: ``dbus-python`` is an optional dependency.
 
 ```bash
-pip install pygobject dbus-python
+pip3 install pygobject dbus-python
 ```
 
 3. Install the application itself
 
 ```bash
-pip install gnomecast
+pip3 install gnomecast
 ```
 
 Run

--- a/gnomecast.py
+++ b/gnomecast.py
@@ -36,6 +36,8 @@ except ImportError:
 Python package "gi" (for building the GUI not found.\n
 If on Debian or Ubuntu, please run:
 $ sudo apt-get install python3-gi\n
+If on Fedora or RedHat, please run:
+$ sudo dnf install python3-gobject
 For other distributions please look up the equivalent package.\n
 If this doesn't work, please report the error here:
 https://github.com/keredson/gnomecast\n

--- a/gnomecast.py
+++ b/gnomecast.py
@@ -33,7 +33,7 @@ except ImportError:
   line = "-"*70
   ERROR_MESSAGE = """
 {}
-Python package "gi" (for building the GU not found.\n
+Python package "gi" (for building the GUI not found.\n
 If on Debian or Ubuntu, please run:
 $ sudo apt-get install python3-gi\n
 For other distributions please look up the equivalent package.\n

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pychromecast
 bottle
 pycaption
 paste
+pygobject
+dbus-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ bottle
 pycaption
 paste
 pygobject
-dbus-python

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     'Programming Language :: Python :: 3',
   ],
   install_requires=['pychromecast','bottle','pycaption','paste','html5lib',
-                    'pygobject', 'dbus-python'],
+                    'pygobject'],
   data_files=[
     ('share/icons/hicolor/16x16/apps', ['icons/gnomecast_16.png']),
     ('share/icons/hicolor/48x48/apps', ['icons/gnomecast_48.png']),

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
   ],
-  install_requires=['pychromecast','bottle','pycaption','paste','html5lib'],
+  install_requires=['pychromecast','bottle','pycaption','paste','html5lib',
+                    'pygobject', 'dbus-python'],
   data_files=[
     ('share/icons/hicolor/16x16/apps', ['icons/gnomecast_16.png']),
     ('share/icons/hicolor/48x48/apps', ['icons/gnomecast_48.png']),


### PR DESCRIPTION
This pull request includes two changes:

1. Add missing dependency to ``setup.py`` and ``requirements.txt``

This pull request adds missing ``pygobject`` dependency to the setup.py file. This dependency is needed to run the application.

Right now the instructions rely on system level ``python3-gi`` package being installed which means it won't work in virtual environments without installing ``pygobject`` PyPi package or relying on system site packages (which is not ideal and not the default behavior anymore).

Keep in mind that this will still work even if ``--system-site-packages`` and OS level approach is used since that package will already be available in virtual environment.

2. Add installation instructions for Fedora

It adds installation instructions which documents which system level package dependencies are needed on Fedora.