### PR TITLE
Fix unable to close / exit the application until the application "init" phase finishes

### DIFF
--- a/gnomecast.py
+++ b/gnomecast.py
@@ -401,7 +401,7 @@ class Gnomecast(object):
   def run(self, fn=None, device=None, subtitles=None):
     self.build_gui()
     self.init_casts(device=device)
-    threading.Thread(target=self.check_ffmpeg).start()
+    threading.Thread(target=self.check_ffmpeg, daemon=True).start()
     t = threading.Thread(target=self.start_server)
     t.daemon = True
     t.start()
@@ -522,7 +522,8 @@ class Gnomecast(object):
     self.cast_store.clear()
     self.cast_store.append([None, "Searching local network - please wait..."])
     self.cast_combo.set_active(0)
-    threading.Thread(target=self.load_casts, kwargs={'device':device}).start()
+    t = threading.Thread(target=self.load_casts, daemon=True, kwargs={'device':device}).start()
+    return t
 
   def inhibit_screensaver(self):
     if not self.saver_interface or self.inhibit_screensaver_cookie: return


### PR DESCRIPTION
## Problem Description

Right now when you start the app, two non-daemon / "blocking" threads are started - check ffmpeg and "init casts".

Those two threads "block" the main GUI loop which means if you press CTRL+C / "x" button, application won't exit until those two threads finish.

Init casts thread discovers Chromecasts on the local network which means it can take quite a while to finish and as mentioned above, you can't "gracefully" exit / close the application until it finishes.

## Proposed Solution

This pull request fixes that by making those two threads daemon threads.

This means CTRL + C / "x" button will work as expected and the application will exit immediately.

There are also other possible approaches, but this one is the simplest and less invasive with the correct end result.