### PR TITLE
Fix unnecessary audio transcoding

### DIFF
--- a/gnomecast.py
+++ b/gnomecast.py
@@ -271,7 +271,7 @@ class Transcoder(object):
     print('Transcoder', fn)
     transcode_container = fmd.container not in ('mp4', 'aac', 'mp3', 'wav')
     self.transcode_video = force_video or not self.can_play_video_codec(video_stream.codec)
-    self.transcode_audio = force_audio or fmd.container not in AUDIO_EXTS or not self.can_play_audio_stream(self.audio_stream)
+    self.transcode_audio = force_audio or fmd.container not in AUDIO_EXTS and not self.can_play_audio_stream(self.audio_stream)
     self.transcode = transcode_container or self.transcode_video or self.transcode_audio
     self.trans_fn = None
 


### PR DESCRIPTION
When I tried to prepare a video so that no transcoding was necessary, I noticed
this was impossible, even if I used exactly the same `ffmpeg` call gnomecast was
using.  I chased this down to an `or` that probably should have been an `and`:
we want to transcode if we have an unsupported audio format *and* we can't play
the embedded audio stream.

Thanks a lot for this project!