### PR TITLE
Fix incorrect Transcorder creation

### DIFF
--- a/gnomecast.py
+++ b/gnomecast.py
@@ -1171,7 +1171,7 @@ class Gnomecast(object):
       fmd = row[8]
       if transcode_next and not transcoder:
         print('prep_next_transcode', fn)
-        transcoder = Transcoder(self.cast, fmd, fmd.audio_streams[0] if fmd.audio_streams else None, lambda did_transcode=None: GLib.idle_add(self.update_status, did_transcode), self.error_callback, transcoder)
+        transcoder = Transcoder(self.cast, fmd, fmd.video_streams[0] if fmd.video_streams else None, fmd.audio_streams[0] if fmd.audio_streams else None, lambda did_transcode=None: GLib.idle_add(self.update_status, did_transcode), self.error_callback, transcoder)
         row[7] = transcoder
         transcode_next = False
       if self.cast and self.fn and self.fn == fn and transcoder and transcoder.done:


### PR DESCRIPTION
One-line fix to add a missing parameter to the creation of the Transcoder for second and subsequent video files. As it was, it appeared that the first transcode never finished and the next was never started.